### PR TITLE
Added failing test when diffing an immutable js list

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "babel-preset-react": "^6.1.18",
     "eslint": "^1.9.0",
     "eslint-plugin-react": "^3.8.0",
+    "immutable": "^3.7.6",
     "jsdom": "^6.5.1",
     "magicpen": "^5.4.0",
     "mocha": "^2.3.3",

--- a/src/tests/unexpected-react-shallow.spec.js
+++ b/src/tests/unexpected-react-shallow.spec.js
@@ -2,6 +2,7 @@ var Unexpected = require('unexpected');
 var UnexpectedReact = require('../unexpected-react');
 
 var React = require('react/addons');
+var Immutable = require('immutable');
 
 var expect = Unexpected.clone()
     .installPlugin(UnexpectedReact);
@@ -549,6 +550,29 @@ describe('unexpected-react-shallow', () => {
                 '  </ClassComponent>\n' +
                 '</div>');
 
+        });
+
+        it('matches immutable array of children in a custom component', function () {
+
+            const items = new Immutable.List([
+                <span className="one">1</span>,
+                <span className="two">2</span>
+            ]);
+
+            renderer.render(
+                <MyDiv>
+                    <ClassComponent test={true} className="foo">
+                        {items.map((item) => item)}
+                    </ClassComponent>
+                </MyDiv>
+            );
+
+            return expect(renderer, 'to have exactly rendered',
+                <div>
+                    <ClassComponent className="foo" test={true}>
+                        <span className="three">3</span>
+                    </ClassComponent>
+                </div>);
         });
 
         it('accepts added children at the end of an array when not using `exactly`', function () {


### PR DESCRIPTION
I've come across a problem when trying to use unexpected-react with Immutable.js lists. Ive added a failing test which produces the following output:

```
  2) unexpected-react-shallow diff matches immutable array of children in a custom component:
     Uncaught TypeError: Cannot read property 'displayName' of undefined
      at ReactElementAdapter.getName (node_modules/unexpected-htmllike-jsx-adapter/lib/ReactElementAdapter.js:72:32)
      at diffElement (node_modules/unexpected-htmllike/lib/diff.js:217:36)
      at diffElementOrWrapper (node_modules/unexpected-htmllike/lib/diff.js:81:25)
      at node_modules/unexpected-htmllike/lib/diff.js:441:13
      at removeTable (node_modules/unexpected-htmllike/node_modules/array-changes-async/lib/arrayChanges.js:36:9)
      at compare (node_modules/unexpected-htmllike/node_modules/array-changes-async/node_modules/arraydiff-async/index.js:112:13)
      at arrayDiff (node_modules/unexpected-htmllike/node_modules/array-changes-async/node_modules/arraydiff-async/index.js:149:5)
      at arrayChanges (node_modules/unexpected-htmllike/node_modules/array-changes-async/lib/arrayChanges.js:35:5)
      at node_modules/unexpected-htmllike/lib/diff.js:440:44
      at tryCatcher (node_modules/unexpected/node_modules/bluebird/js/main/util.js:26:23)
      at Promise._resolveFromResolver (node_modules/unexpected/node_modules/bluebird/js/main/promise.js:476:31)
      at new Promise (node_modules/unexpected/node_modules/bluebird/js/main/promise.js:69:37)
      at Function.makePromise [as promise] (node_modules/unexpected/lib/makePromise.js:13:16)
      at tryDiffChildren (node_modules/unexpected-htmllike/lib/diff.js:439:19)
      at diffChildren (node_modules/unexpected-htmllike/lib/diff.js:409:12)
      at diffContent (node_modules/unexpected-htmllike/lib/diff.js:357:12)
      at diffElement (node_modules/unexpected-htmllike/lib/diff.js:238:32)
      at diffElementOrWrapper (node_modules/unexpected-htmllike/lib/diff.js:81:25)
      at node_modules/unexpected-htmllike/lib/diff.js:441:13
      at removeTable (node_modules/unexpected-htmllike/node_modules/array-changes-async/lib/arrayChanges.js:36:9)
      at compare (node_modules/unexpected-htmllike/node_modules/array-changes-async/node_modules/arraydiff-async/index.js:112:13)
      at arrayDiff (node_modules/unexpected-htmllike/node_modules/array-changes-async/node_modules/arraydiff-async/index.js:149:5)
      at arrayChanges (node_modules/unexpected-htmllike/node_modules/array-changes-async/lib/arrayChanges.js:35:5)
      at node_modules/unexpected-htmllike/lib/diff.js:440:44
      at tryCatcher (node_modules/unexpected/node_modules/bluebird/js/main/util.js:26:23)
      at Promise._resolveFromResolver (node_modules/unexpected/node_modules/bluebird/js/main/promise.js:476:31)
      at new Promise (node_modules/unexpected/node_modules/bluebird/js/main/promise.js:69:37)
      at Function.makePromise [as promise] (node_modules/unexpected/lib/makePromise.js:13:16)
      at tryDiffChildren (node_modules/unexpected-htmllike/lib/diff.js:439:19)
      at diffChildren (node_modules/unexpected-htmllike/lib/diff.js:409:12)
      at diffContent (node_modules/unexpected-htmllike/lib/diff.js:357:12)
      at diffElement (node_modules/unexpected-htmllike/lib/diff.js:238:32)
      at diffElementOrWrapper (node_modules/unexpected-htmllike/lib/diff.js:81:25)
      at Object.diffElements (node_modules/unexpected-htmllike/lib/diff.js:71:12)
      at Object.diff (node_modules/unexpected-htmllike/lib/index.js:40:34)
      at Function.<anonymous> (assertions.js:129:28)
      at executeExpect (node_modules/unexpected/lib/Unexpected.js:1070:50)
      at node_modules/unexpected/lib/Unexpected.js:1034:24
      at Function.wrappedExpectProto.callInNestedContext (node_modules/unexpected/lib/createWrappedExpectProto.js:54:42)
      at wrappedExpect (node_modules/unexpected/lib/Unexpected.js:1033:34)
      at Function.<anonymous> (assertions.js:206:16)
      at executeExpect (node_modules/unexpected/lib/Unexpected.js:1070:50)
      at Unexpected.expect (node_modules/unexpected/lib/Unexpected.js:1078:22)
      at Context.<anonymous> (unexpected-react-shallow.spec.js:570:20)
      at Context.wrapper (node_modules/unexpected/lib/testFrameworkPatch.js:72:41)
```

It's a bit beyond me exactly what the issue is, do you have any idea?

Great library btw! I've really enjoyed using it.