### PR TITLE
Upgrade to react v15

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,9 @@
     "test"
   ],
   "peerDependencies": {
-    "react": "^0.13.0 || ^0.14.0"
+    "react": "^0.14.0 || ^15.0.0",
+    "react-addons-test-utils": "^0.14.0 || ^15.0.0",
+    "react-dom": "^0.14.0 || ^15.0.0"
   },
   "devDependencies": {
     "babel": "5.x.x",
@@ -38,7 +40,9 @@
     "magicpen": "^5.7.0",
     "mocha": "^2.3.3",
     "object-assign": "^4.0.1",
-    "react": "^0.14.7",
+    "react": "^15.0.0",
+    "react-addons-test-utils": "^15.0.0",
+    "react-dom": "^15.0.0",
     "unexpected": "^10.10.12",
     "unexpected-documentation-site-generator": "^4.0.0",
     "unexpected-markdown": "^1.4.1"

--- a/src/deepAssertions.js
+++ b/src/deepAssertions.js
@@ -2,9 +2,10 @@ import RenderHook from 'react-render-hook';
 import UnexpectedHtmlLike from 'unexpected-htmllike';
 import RenderedReactElementAdapter from 'unexpected-htmllike-reactrendered-adapter';
 import ReactElementAdapter from 'unexpected-htmllike-jsx-adapter';
-import React from 'react/addons';
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
+import { findDOMNode } from 'react-dom';
 
-const TestUtils = React.addons.TestUtils;
 const PENDING_SHALLOW_EVENT_TYPE = Symbol('Pending shallow event');
 const PENDING_DEEP_EVENT_TYPE = Symbol('Pending deep event');
 
@@ -260,9 +261,9 @@ function installInto(expect) {
     });
 
     function triggerEvent(component, target, eventName, eventArgs) {
-        let targetDOM = React.findDOMNode(component);
+        let targetDOM = findDOMNode(component);
         if (target) {
-            targetDOM = React.findDOMNode(target.element.getPublicInstance());
+            targetDOM = findDOMNode(target.element.getPublicInstance());
         }
 
         if (typeof TestUtils.Simulate[eventName] !== 'function') {

--- a/src/error-tests/out-of-order.spec.js
+++ b/src/error-tests/out-of-order.spec.js
@@ -5,8 +5,8 @@
 
 const EmulateDom = require( '../testHelpers/emulateDom');
 
-const React = require('react/addons');
-const TestUtils = React.addons.TestUtils;
+const React = require('react');
+const TestUtils = require('react-addons-test-utils');
 
 const Unexpected = require('unexpected');
 const UnexpectedReact = require('../unexpected-react');

--- a/src/shallowAssertions.js
+++ b/src/shallowAssertions.js
@@ -1,9 +1,8 @@
 import RenderHook from 'react-render-hook';
 import UnexpectedHtmlLike from 'unexpected-htmllike';
 import ReactElementAdapter from 'unexpected-htmllike-jsx-adapter';
-import React from 'react/addons';
-
-const TestUtils = React.addons.TestUtils;
+import React from 'react';
+import TestUtils from 'react-addons-test-utils';
 
 const PENDING_SHALLOW_EVENT_TYPE = Symbol('Pending shallow event');
 
@@ -300,8 +299,8 @@ function installInto(expect) {
             eventArgs: eventArgs
         });
     });
-    
-    expect.addAssertion(['<ReactPendingShallowEvent> to contain [exactly] <ReactElement>', 
+
+    expect.addAssertion(['<ReactPendingShallowEvent> to contain [exactly] <ReactElement>',
         '<ReactPendingShallowEvent> to contain [with all children] [with all wrappers] <ReactElement>'], function (expect, subject, expected) {
 
         triggerEvent(subject.renderer, subject.target, subject.eventName, subject.eventArgs);

--- a/src/tests/Select.spec.js
+++ b/src/tests/Select.spec.js
@@ -11,9 +11,9 @@ const EmulateDom = require( '../testHelpers/emulateDom');
 const Unexpected = require('unexpected');
 const UnexpectedReact = require('../unexpected-react');
 
-const React = require('react/addons');
-
-const TestUtils = React.addons.TestUtils;
+const React = require('react');
+const TestUtils = require('react-addons-test-utils');
+const { findDOMNode } = require('react-dom');
 
 const Select = require('./components/Select');
 const SelectOption = require('./components/SelectOption');
@@ -47,7 +47,7 @@ describe('Select', () => {
 
     it('should show the menu when clicked', () => {
 
-        TestUtils.Simulate.click(React.findDOMNode(component));
+        TestUtils.Simulate.click(findDOMNode(component));
         return expect(component, 'to have rendered',
             <div>
                 <SelectOption />
@@ -58,7 +58,7 @@ describe('Select', () => {
 
     it('renders the options', () => {
 
-        TestUtils.Simulate.click(React.findDOMNode(component));
+        TestUtils.Simulate.click(findDOMNode(component));
         return expect(component, 'to have rendered',
             <div>
                 <li>one</li>
@@ -70,7 +70,7 @@ describe('Select', () => {
 
     it('renders a particular option', () => {
 
-        TestUtils.Simulate.click(React.findDOMNode(component));
+        TestUtils.Simulate.click(findDOMNode(component));
 
         return expect(component, 'to contain',
             <li id={ expect.it('to match', /unique_[0-9]+/) }>two</li>
@@ -79,7 +79,7 @@ describe('Select', () => {
 
     it('renders a particular option', () => {
 
-        TestUtils.Simulate.click(React.findDOMNode(component));
+        TestUtils.Simulate.click(findDOMNode(component));
 
         return expect(component, 'to contain',
             <li>{ expect.it('to match', /th/) }</li>
@@ -88,7 +88,7 @@ describe('Select', () => {
 
     it('renders with the right class', () => {
 
-        TestUtils.Simulate.click(React.findDOMNode(component));
+        TestUtils.Simulate.click(findDOMNode(component));
 
         return expect(component, 'to contain',
             <li className="Select__item--unselected" />

--- a/src/tests/issue9.spec.js
+++ b/src/tests/issue9.spec.js
@@ -3,9 +3,8 @@ const EmulateDom = require( '../testHelpers/emulateDom');
 const Unexpected = require('unexpected');
 const UnexpectedReact = require('../unexpected-react');
 
-const React = require('react/addons');
-
-const TestUtils = React.addons.TestUtils;
+const React = require('react');
+const TestUtils = require('react-addons-test-utils');
 
 const expect = Unexpected
     .clone()

--- a/src/tests/unexpected-react-deep.spec.js
+++ b/src/tests/unexpected-react-deep.spec.js
@@ -119,7 +119,7 @@ describe('unexpected-react (deep rendering)', () => {
         it('identifies a rendered component', () => {
 
             const component = TestUtils.renderIntoDocument(<div className="foo" />);
-            return expect(TestUtils.isDOMComponent(component), 'to be ok');
+            expect(component, 'to be a', 'RenderedReactElement');
         });
 
     });

--- a/src/tests/unexpected-react-deep.spec.js
+++ b/src/tests/unexpected-react-deep.spec.js
@@ -13,9 +13,9 @@ const EmulateDom = require( '../testHelpers/emulateDom');
 const Unexpected = require('unexpected');
 const UnexpectedReact = require('../unexpected-react');
 
-const React = require('react/addons');
-
-const TestUtils = React.addons.TestUtils;
+const React = require('react');
+const TestUtils = require('react-addons-test-utils');
+const { findDOMNode } = require('react-dom');
 
 const expect = Unexpected.clone()
     .use(UnexpectedReact);
@@ -119,7 +119,7 @@ describe('unexpected-react (deep rendering)', () => {
         it('identifies a rendered component', () => {
 
             const component = TestUtils.renderIntoDocument(<div className="foo" />);
-            expect(component, 'to be a', 'RenderedReactElement');
+            return expect(TestUtils.isDOMComponent(component), 'to be ok');
         });
 
     });
@@ -263,7 +263,7 @@ describe('unexpected-react (deep rendering)', () => {
         it('updates on change', () => {
 
             const component = TestUtils.renderIntoDocument(<CustomComp className="bar" useEvents={true} />);
-            TestUtils.Simulate.click(React.findDOMNode(component));
+            TestUtils.Simulate.click(findDOMNode(component));
 
             return expect(component, 'to have rendered',
                     <div className="bar" data-click-count={1} />

--- a/src/tests/unexpected-react-deep.spec.js
+++ b/src/tests/unexpected-react-deep.spec.js
@@ -116,9 +116,9 @@ describe('unexpected-react (deep rendering)', () => {
 
     describe('identify', () => {
 
-        it('identifies a rendered component', () => {
+        it('identifies a rendered ES6 component', () => {
 
-            const component = TestUtils.renderIntoDocument(<div className="foo" />);
+            const component = TestUtils.renderIntoDocument(<MyDiv className="foo" />);
             expect(component, 'to be a', 'RenderedReactElement');
         });
 

--- a/src/tests/unexpected-react-shallow.spec.js
+++ b/src/tests/unexpected-react-shallow.spec.js
@@ -1,7 +1,8 @@
 var Unexpected = require('unexpected');
 var UnexpectedReact = require('../unexpected-react');
 
-var React = require('react/addons');
+const React = require('react');
+const TestUtils = require('react-addons-test-utils');
 var Immutable = require('immutable');
 
 var PropTypes = React.PropTypes;
@@ -89,8 +90,8 @@ describe('unexpected-react-shallow', () => {
     var renderer, renderer2;
 
     beforeEach(function () {
-        renderer = React.addons.TestUtils.createRenderer();
-        renderer2 = React.addons.TestUtils.createRenderer();
+        renderer = TestUtils.createRenderer();
+        renderer2 = TestUtils.createRenderer();
 
     });
 

--- a/src/tests/unexpected-react-shallow.spec.js
+++ b/src/tests/unexpected-react-shallow.spec.js
@@ -1,8 +1,8 @@
 var Unexpected = require('unexpected');
 var UnexpectedReact = require('../unexpected-react');
 
-const React = require('react');
-const TestUtils = require('react-addons-test-utils');
+var React = require('react');
+var TestUtils = require('react-addons-test-utils');
 var Immutable = require('immutable');
 
 var PropTypes = React.PropTypes;


### PR DESCRIPTION
As discussed in #17 

Test suite passed with both 0.14.x and 15.0.1

Unfortunately I'm not in a position where I have a large test suite to attempt to upgrade (I'm just about to introduce unexpected-react) so any help on that front would be awesome.

I had to introduce peer dependencies on both react-dom (for findDomNode) and react-addons-test-utils.

Only "real" change was in [src/tests/unexpected-react-deep.spec.js](https://github.com/bruderstein/unexpected-react/commit/921592d8a36f50b5ad91a57bb640d7c71499486e#diff-26ef4a03b7917600bd4d336fddb3a757L122). The component no longer has a `obj.constructor.name` equal to 'RenderedReactElement'. I hope the test update is adequate.

From a clean `npm install`s output it looks like there's another upgrade to be made in unexpected-htmllike-reactrendered-adapter, as it has a peerDep for react in 0.13 or 0.14 too. 

```
├─┬ unexpected-htmllike-reactrendered-adapter@1.0.1 
│ └── UNMET PEER DEPENDENCY react@^0.13.0 || ^0.14.0
```

Is that also something you are bold enough to outsource? :-)