### PR TITLE
Remove documentation generator from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,13 +44,12 @@
     "react-addons-test-utils": "^15.0.0",
     "react-dom": "^15.0.0",
     "unexpected": "^10.10.12",
-    "unexpected-documentation-site-generator": "^4.0.0",
+    "unexpected-documentation-site-generator": "^4.1.0",
     "unexpected-markdown": "^1.4.1"
   },
   "dependencies": {
     "magicpen-prism": "^2.2.1",
     "react-render-hook": "^0.1.1",
-    "unexpected-documentation-site-generator": "^4.1.0",
     "unexpected-htmllike": "^2.0.0",
     "unexpected-htmllike-jsx-adapter": "^0.5.1",
     "unexpected-htmllike-reactrendered-adapter": "^2.0.0"


### PR DESCRIPTION
Since it already exists in `devDependencies`. Also means it won't get installed when using `unexpected-react` as a dependency. 