### PR TITLE
Allow assertions of objects without a proto

### DIFF
--- a/src/tests/issue31.spec.js
+++ b/src/tests/issue31.spec.js
@@ -1,0 +1,23 @@
+const Unexpected = require('unexpected');
+const UnexpectedReact = require('../unexpected-react');
+
+const expect = Unexpected
+  .clone()
+  .use(UnexpectedReact);
+
+
+describe('issue 31 - asserting on objects with no prototype', function () {
+
+  it('handles objects without __prop__', function () {
+    var result = {
+      id: '666',
+      name: 'Chuck Norris'
+    };
+    result.__proto__ = null;
+
+    return expect(result, 'to satisfy', {
+      id: '666',
+      name: 'Chuck Norris'
+    });
+  });
+});

--- a/src/tests/issue31.spec.js
+++ b/src/tests/issue31.spec.js
@@ -5,7 +5,6 @@ const expect = Unexpected
   .clone()
   .use(UnexpectedReact);
 
-
 describe('issue 31 - asserting on objects with no prototype', function () {
 
   it('handles objects without __prop__', function () {
@@ -20,4 +19,5 @@ describe('issue 31 - asserting on objects with no prototype', function () {
       name: 'Chuck Norris'
     });
   });
+
 });

--- a/src/types.js
+++ b/src/types.js
@@ -108,33 +108,33 @@ function installInto(expect) {
             output.append(inspect(value.getRenderOutput()));
         }
     });
-    
-    
-    
+
+
+
     expect.addType({
        name: 'ReactTestRenderer',
        base: 'object',
        identify: function (value) {
            return value && typeof value === 'object' &&
-               value.hasOwnProperty('_component') &&
+               ({}).hasOwnProperty.call(value, '_component') &&
                typeof value.toJSON === 'function' &&
                typeof value.unmount === 'function' &&
                typeof value.update === 'function' &&
                typeof value.getInstance === 'function';
        },
-    
+
         inspect: function (value, depth, output, inspect) {
             output.append(inspect(TestRendererTypeWrapper.getTestRendererOutputWrapper(value)));
         }
     });
-    
+
     expect.addType({
         name: 'ReactTestRendererOutput',
         base: 'object',
         identify: function (value) {
             return TestRendererTypeWrapper.isTestRendererOutputWrapper(value);
         },
-        
+
         inspect: function (value, depth, output, inspect) {
             return htmlLikeTestRenderer.inspect(TestRendererTypeWrapper.getRendererOutputJson(value), depth, output, inspect);
         }

--- a/src/types.js
+++ b/src/types.js
@@ -116,7 +116,8 @@ function installInto(expect) {
        base: 'object',
        identify: function (value) {
            return value && typeof value === 'object' &&
-               ({}).hasOwnProperty.call(value, '_component') &&
+               typeof value.hasOwnProperty === 'function' &&
+               value.hasOwnProperty('_component') &&
                typeof value.toJSON === 'function' &&
                typeof value.unmount === 'function' &&
                typeof value.update === 'function' &&


### PR DESCRIPTION
@bruderstein thanks for pointing out where the issue was!

It will use an other's objects prototype to check for `hasOwnProperty`.

closes #31 