### PR TITLE
Fix bug where the display section in snapshots was just a JavaScript object

### DIFF
--- a/src/helpers/snapshots.js
+++ b/src/helpers/snapshots.js
@@ -51,7 +51,7 @@ class UnexpectedSnapshotState {
       if (content) {
         Object.keys(content).reduce((agg, testKey) => {
           agg[testKey] = expect.output.clone().annotationBlock(function () {
-            this.append(expect.inspect(content[testKey]));
+            this.append(expect.inspect(rawAdapter.deserialize(content[testKey])));
           }).toString();
           return agg;
         }, contentOutput)


### PR DESCRIPTION
I was running into a problem that snapshot tests writes a display value that is just a object blob:

```js
/////////////////// Avatar with the type system renders a system avatar 1 ///////////////////

// {
//   children: [ { children: ..., props: ..., type: 'img' } ],
//   props: { className: 'avatar status_default type_system size_medium', style: {}, tabIndex: undefined, testId: undefined, title: undefined, tooltipPositioning: undefined },
//   type: 'View'
// }

exports[`Avatar with the type system renders a system avatar 1`] = {children:[{children:[],props:{alt:"Zendesk",onError:undefined,onLoad:undefined,src:"zendesk.png"},type:"img"}],props:{className:"avatar status_default type_system size_medium",style:{},tabIndex:undefined,testId:undefined,title:undefined,tooltipPositioning:undefined},type:"View"};
// ===========================================================================
```

where snapshots that is actually updated is display as:

```js
/////////////////// Avatar with the status present renders a present avatar 1 ///////////////////

// <View className="avatar status_present type_human size_medium" style={{}}>
//   <img alt="Zendesk" src="zendesk.png" />
// </View>

exports[`Avatar with the status present renders a present avatar 1`] = {children:[{children:[],props:{alt:"Zendesk",onError:undefined,onLoad:undefined,src:"zendesk.png"},type:"img"}],props:{className:"avatar status_present type_human size_medium",style:{},tabIndex:undefined,testId:undefined,title:undefined,tooltipPositioning:undefined},type:"View"};
// ===========================================================================
```

I narrowed the problem to being that this line:
https://github.com/bruderstein/unexpected-react/blob/master/src/helpers/snapshots.js#L54
receives an object:

```js
    { children: [ { children: [], props: [Object], type: 'img' } ],
      props:
       { className: 'avatar status_present type_human size_medium',
         style: {},
         tabIndex: undefined,
         testId: undefined,
         title: undefined,
         tooltipPositioning: undefined },
      type: 'View' }
```

Snapshot updates uses this line:
https://github.com/bruderstein/unexpected-react/blob/master/src/helpers/snapshots.js#L88
and receives a real React component:

```js
    Function {
      type: 'View',
      props:
       { className: 'avatar status_present type_human size_medium',
         style: {},
         tabIndex: undefined,
         testId: undefined,
         title: undefined,
         tooltipPositioning: undefined },
      children: [ Function { type: 'img', props: [Object], children: [] } ] }
```

Tested it with jest v18 and v19 in the host project I'm having the problem.