### PR TITLE
Fix comments in snapshots

### DIFF
--- a/src/test-renderer-jest.js
+++ b/src/test-renderer-jest.js
@@ -33,13 +33,6 @@ module.exports = {
     jestSnapshotAssertions.installInto(expect);
     snapshotFunctionType.installInto(expect);
     snapshotFunctionAssertions.installInto(expect);
-    expect.addType({
-          name: 'RawReactTestRendererJson',
-          base: 'object',
-          identify: function (value) {
-              return value && typeof value === 'object' && value.props && value.children && value.type;
-          }
-      });
 
       expect.addAssertion('<RawReactTestRendererJson> to match snapshot', function (expect, subject) {
           expect.errorMode = 'bubble';

--- a/src/test-renderer.js
+++ b/src/test-renderer.js
@@ -10,13 +10,7 @@ module.exports = {
 
       types.installInto(expect);
       testRendererAssertions.installInto(expect);
-      expect.addType({
-          name: 'RawReactTestRendererJson',
-          base: 'object',
-          identify: function (value) {
-              return value && typeof value === 'object' && value.props && value.children && value.type;
-          }
-      });
+
       expect.addAssertion([
           '<ReactTestRenderer|ReactTestRendererOutput> to match snapshot',
           '<ReactTestRenderer|ReactTestRendererOutput> to satisfy snapshot',

--- a/src/tests/testRenderer/snapshot.spec.js
+++ b/src/tests/testRenderer/snapshot.spec.js
@@ -168,7 +168,17 @@ describe('snapshots', function () {
           .and('to match', /exports\[`single test name 1`]/)
       ]);
     });
-    
+
+    it('writes a new snapshot comment', function () {
+
+      // Confirm we wrote the file with the old and new entries
+      expect(fs.writeFileSync, 'to have a call satisfying', [
+        snapshotPath,
+        expect.it('to match', /\/\/ <button onClick={/)
+          .and('to match', /\/\/ <\/button>/)
+      ]);
+    });
+
     it('creates the correct snapshot', function () {
       // Confirm it is parseable and contains the right thing
       const newSnapshot = loadSnapshotMock(snapshotPath);
@@ -177,7 +187,7 @@ describe('snapshots', function () {
         children: ['Clicked ', '0', ' times']
       });
     });
-    
+
     it('increments the added count in the state', function () {
       expect(state, 'to satisfy', {
         snapshotState: {
@@ -398,7 +408,17 @@ describe('snapshots', function () {
         ]
       ]);
     });
-    
+
+    it('writes the new snapshot comment', function () {
+      expect(fs.writeFileSync, 'to have calls satisfying', [
+        [
+          snapshotPath,
+          expect.it('to match', /\/\/ <button onClick={/)
+              .and('to match', /\/\/ <\/button>/)
+        ]
+      ]);
+    });
+
     it('writes the correct snapshot', function () {
       const snapshot = loadSnapshotMock(snapshotPath);
       expect(snapshot, 'to satisfy', {

--- a/src/tests/testRenderer/snapshot.spec.js
+++ b/src/tests/testRenderer/snapshot.spec.js
@@ -175,7 +175,8 @@ describe('snapshots', function () {
       expect(fs.writeFileSync, 'to have a call satisfying', [
         snapshotPath,
         expect.it('to match', /\/\/ <button onClick={/)
-          .and('to match', /\/\/ <\/button>/)
+            .and('to match', /\/\/ <\/button>/)
+            .and('not to match', /\/\/\s*children:/)
       ]);
     });
 
@@ -415,6 +416,7 @@ describe('snapshots', function () {
           snapshotPath,
           expect.it('to match', /\/\/ <button onClick={/)
               .and('to match', /\/\/ <\/button>/)
+              .and('not to match', /\/\/\s*children:/)
         ]
       ]);
     });

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -143,10 +143,18 @@ function installInto(expect) {
             return htmlLikeTestRenderer.inspect(TestRendererTypeWrapper.getRendererOutputJson(value), depth, output, inspect);
         }
     });
-    
+
+    expect.addType({
+        name: 'RawReactTestRendererJson',
+        base: 'object',
+        identify: function (value) {
+            return value && typeof value === 'object' && value.props && value.children && value.type;
+        }
+    });
+
     expect.addType({
         name: 'ReactRawObjectElement',
-        base: 'object',
+        base: 'RawReactTestRendererJson',
         identify: function (value) {
             return rawAdapter.isRawElement(value);
         },
@@ -155,6 +163,7 @@ function installInto(expect) {
             return htmlLikeRaw.inspect(value, depth, output, inspect);
         }
     });
+
 }
 
 export default { installInto };


### PR DESCRIPTION
Snapshots were being written with comments with raw JSON rather than
the JSX. They were being identified as the RawReactTestRendererJson
when `inspect` ran, which meant the raw JSON was outputted. Now they
are identified correctly.

I think because of the new hierarchy, it now actually outputs
correctly in the test, but we need @sunesimonsen's fix to properly
fix this - I'm not sure what combination is actually making this work - the RawReactTestRendererJson doesn't have an `inspect` method.