### PR TITLE
to render as, to have rendered: Always provide the rendered output as the fulfillment value

### DIFF
--- a/src/assertions/AssertionGenerator.js
+++ b/src/assertions/AssertionGenerator.js
@@ -72,7 +72,8 @@ AssertionGenerator.prototype._installEqualityAssertions = function (expect) {
       `<${actualTypeName}> to have rendered [with all children] [with all wrappers] [with all classes] [with all attributes] <${expectedTypeName}>`],
     function (expect, subject, renderOutput) {
       var actual = getRenderOutput(subject);
-      return expect(actual, 'to have [exactly] rendered [with all children] [with all wrappers] [with all classes] [with all attributes]', renderOutput);
+      return expect(actual, 'to have [exactly] rendered [with all children] [with all wrappers] [with all classes] [with all attributes]', renderOutput)
+        .then(() => subject);
     });
   
   expect.addAssertion([
@@ -109,6 +110,7 @@ AssertionGenerator.prototype._installEqualityAssertions = function (expect) {
           }
         });
       }
+      return result;
     });
   });
   

--- a/src/tests/general/unexpected-react-deep.spec.js
+++ b/src/tests/general/unexpected-react-deep.spec.js
@@ -370,6 +370,13 @@ describe('unexpected-react (deep rendering)', () => {
 
         });
 
+        it('provides the rendered component as the fulfillment value', () => {
+            const component = TestUtils.renderIntoDocument(<CustomComp />);
+
+            return expect(component, 'to have rendered', <div />)
+                .then(rendered => expect(rendered, 'to be', component));
+        });
+
     });
 
     describe('contains', () => {
@@ -1057,6 +1064,11 @@ describe('unexpected-react (deep rendering)', () => {
                     '  />',
                     '</CustomComp>'
                 ].join('\n'));
+        });
+
+        it('provides the rendered component as the fulfillment value', function () {
+            return expect(<CustomComp />, 'to deeply render as', <CustomComp />)
+                .then(customComp => expect(customComp, 'to be a', 'RenderedReactElement'));
         });
     });
 });

--- a/src/tests/general/unexpected-react-shallow.spec.js
+++ b/src/tests/general/unexpected-react-shallow.spec.js
@@ -2418,6 +2418,11 @@ describe('unexpected-react-shallow', () => {
                     '/>'
                 ].join('\n'));
         });
+
+        it('provides the rendered component as the fulfillment value', function () {
+            return expect(<FunctionComp />, 'to render as', <div />)
+                .then(functionComp => expect(functionComp, 'to be a', 'ReactShallowRenderer'));
+        });
     });
 
 });


### PR DESCRIPTION
As discussed on https://gitter.im/unexpectedjs/unexpected