### PR TITLE
Stop relying on the old unexpectedType.diff output format

### DIFF
--- a/src/assertions/AssertionGenerator.js
+++ b/src/assertions/AssertionGenerator.js
@@ -104,9 +104,7 @@ AssertionGenerator.prototype._installEqualityAssertions = function (expect) {
       if (result.weight !== 0) {
         return expect.fail({
           diff: function (output, diff, inspect) {
-            return {
-              diff: output.append(testHtmlLike.render(result, output.clone(), diff, inspect))
-            };
+            return output.append(testHtmlLike.render(result, output.clone(), diff, inspect));
           }
         });
       }
@@ -148,9 +146,7 @@ AssertionGenerator.prototype._installEqualityAssertions = function (expect) {
         if (result.found) {
           expect.fail({
             diff: (output, diff, inspect) => {
-              return {
-                diff: output.error('but found the following match').nl().append(testHtmlLike.render(result.bestMatch, output.clone(), diff, inspect))
-              };
+              return output.error('but found the following match').nl().append(testHtmlLike.render(result.bestMatch, output.clone(), diff, inspect));
             }
           });
         }
@@ -160,9 +156,7 @@ AssertionGenerator.prototype._installEqualityAssertions = function (expect) {
       if (!result.found) {
         expect.fail({
           diff: function (output, diff, inspect) {
-            return {
-              diff: output.error('the best match was').nl().append(testHtmlLike.render(result.bestMatch, output.clone(), diff, inspect))
-            };
+            return output.error('the best match was').nl().append(testHtmlLike.render(result.bestMatch, output.clone(), diff, inspect));
           }
         });
       }
@@ -233,11 +227,9 @@ AssertionGenerator.prototype._installQueriedFor = function (expect) {
       if (!result.found) {
         expect.fail({
           diff: (output, diff, inspect) => {
-            const resultOutput = {
-              diff: output.error('`queried for` found no match.')
-            };
+            const resultOutput = output.error('`queried for` found no match.');
             if (result.bestMatch) {
-              resultOutput.diff.error('  The best match was')
+              resultOutput.error('  The best match was')
                 .nl()
                 .append(testHtmlLike.render(result.bestMatch, output.clone(), diff, inspect));
             }


### PR DESCRIPTION
It might be removed in Unexpected 11: https://github.com/unexpectedjs/unexpected/pull/407

Requires: https://github.com/bruderstein/unexpected-htmllike/pull/4