### PR TITLE
Support `null` and `string` rendered values.

### DIFF
--- a/src/tests/testRenderer/unexpected-react-testrenderer.spec.js
+++ b/src/tests/testRenderer/unexpected-react-testrenderer.spec.js
@@ -92,7 +92,17 @@ describe('unexpected-react (test renderer)', function () {
       const comp = ReactTestRenderer.create(<ClassComponent content={<span>hi</span>} />);
       expect(comp, 'to have rendered', <div className="class-component"><span>hi</span></div>);
     });
-    
+
+    it('works with strings', function () {
+      const comp = ReactTestRenderer.create(() => 'foo');
+      expect(comp, 'to have rendered', 'foo');
+    });
+
+    it('works with nulls', function () {
+      const comp = ReactTestRenderer.create(() => null);
+      expect(comp, 'to have rendered', null);
+    });
+
     it('highlights the error if the content does not match', function () {
   
       const comp = ReactTestRenderer.create(<ClassComponent content={<span>hi</span>} />);

--- a/src/types/types.js
+++ b/src/types/types.js
@@ -20,8 +20,9 @@ function installInto(expect) {
 
         identify: function (value) {
             return React.isValidElement(value) ||
+                value === null ||
+                typeof value === 'string' ||
                 (typeof value === 'object' &&
-                value !== null &&
                 (typeof value.type === 'function' || typeof value.type === 'string') &&
                 typeof value.hasOwnProperty === 'function' &&
                 value.hasOwnProperty('props') &&


### PR DESCRIPTION
[wip] Testing CI right now 😄 

Also I'm not sure if this needs support in other places like the DOM renderer... but this works for my use case right now. Happy to have feedback 🎉 

Closes https://github.com/bruderstein/unexpected-react/issues/16.