### PR TITLE
Add missing mkdirp dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
   "dependencies": {
     "js-writer": "^1.3.0",
     "magicpen-prism": "^2.4.0",
+    "mkdirp": "^1.0.4",
     "unexpected-htmllike": "^2.2.0",
     "unexpected-htmllike-jsx-adapter": "^1.0.3",
     "unexpected-htmllike-raw-adapter": "^1.0.1",


### PR DESCRIPTION
Without this a fresh install using Jest fails:

```
  ● Test suite failed to run

    Cannot find module 'mkdirp' from 'node_modules/unexpected-react/lib/helpers/snapshots.js'

    Require stack:
      node_modules/unexpected-react/lib/helpers/snapshots.js
      node_modules/unexpected-react/lib/assertions/jestSnapshotTestRendererAssertions.js
      node_modules/unexpected-react/lib/test-renderer-jest.js
      node_modules/unexpected-react/test-renderer-jest.js
      src/__tests__/ClickCounter.spec.js
```