### PR TITLE
Fix "When testing, code that causes React state updates should be wrapped into act"

### DIFF
--- a/src/assertions/testRendererAssertions.js
+++ b/src/assertions/testRendererAssertions.js
@@ -1,3 +1,4 @@
+import { act } from 'react-test-renderer';
 import ReactElementAdapter from 'unexpected-htmllike-jsx-adapter';
 import TestRendererAdapter from 'unexpected-htmllike-testrenderer-adapter';
 import * as TestRendererTypeWrapper from '../types/test-renderer-type-wrapper';
@@ -21,7 +22,7 @@ function installInto(expect) {
         }
       });
     }
-    handler(eventArgs);
+    act(() => handler(eventArgs));
     return renderer;
   }
   


### PR DESCRIPTION
When I use the `with event` assertion for `ReactTestRenderer`, I get this warning. So this pull request will fix that.